### PR TITLE
feat: macOS 原生窗口支持 & 跟随系统主题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Agents files
+AGENTS.md
+CLAUDE.md

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "lenslink",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lenslink",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@google/generative-ai": "^0.24.1",
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.5.0",
         "@tauri-apps/plugin-fs": "^2.4.5",
         "@tauri-apps/plugin-opener": "^2",
+        "@tauri-apps/plugin-os": "^2.3.2",
         "libraw-wasm": "^1.1.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
@@ -74,6 +75,7 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -1485,6 +1487,15 @@
         "@tauri-apps/api": "^2.8.0"
       }
     },
+    "node_modules/@tauri-apps/plugin-os": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-os/-/plugin-os-2.3.2.tgz",
+      "integrity": "sha512-n+nXWeuSeF9wcEsSPmRnBEGrRgOy6jjkSU+UVCOV8YUGKb2erhDOxis7IqRXiRVHhY8XMKks00BJ0OAdkpf6+A==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmmirror.com/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1550,6 +1561,7 @@
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1720,6 +1732,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2145,6 +2158,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -2361,6 +2375,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2408,6 +2423,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -2577,6 +2593,7 @@
       "resolved": "https://registry.npmmirror.com/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -2965,6 +2982,7 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@tauri-apps/plugin-dialog": "^2.5.0",
     "@tauri-apps/plugin-fs": "^2.4.5",
     "@tauri-apps/plugin-opener": "^2",
+    "@tauri-apps/plugin-os": "^2.3.2",
     "libraw-wasm": "^1.1.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -430,6 +430,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1165,6 +1171,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1826,6 +1842,7 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
  "tauri-plugin-opener",
+ "tauri-plugin-os",
  "tauri-plugin-window-state",
  "trash",
 ]
@@ -2050,6 +2067,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2180,6 +2209,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-location"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-core-text"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2283,8 +2322,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
  "bitflags 2.10.0",
+ "block2",
  "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
  "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-core-text",
+ "objc2-foundation",
+ "objc2-quartz-core",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
+dependencies = [
+ "objc2",
  "objc2-foundation",
 ]
 
@@ -2336,6 +2394,22 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "os_info"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4022a17595a00d6a369236fdae483f0de7f0a339960a53118b818238e132224"
+dependencies = [
+ "android_system_properties",
+ "log",
+ "nix",
+ "objc2",
+ "objc2-foundation",
+ "objc2-ui-kit",
+ "serde",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3448,6 +3522,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sys-locale"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3709,6 +3792,24 @@ dependencies = [
  "url",
  "windows 0.61.3",
  "zbus",
+]
+
+[[package]]
+name = "tauri-plugin-os"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8f08346c8deb39e96f86973da0e2d76cbb933d7ac9b750f6dc4daf955a6f997"
+dependencies = [
+ "gethostname",
+ "log",
+ "os_info",
+ "serde",
+ "serde_json",
+ "serialize-to-javascript",
+ "sys-locale",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.17",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "lenslink"
 version = "0.1.1"
-description = "A Tauri App"
-authors = ["you"]
+description = "LensLink - RAW + JPG Manager"
+authors = ["AGPEIM"]
+repository = "https://github.com/AGPEIM/lenslink"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -27,4 +27,5 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 kamadak-exif = "0.5"
 trash = "5.1"
+tauri-plugin-os = "2.3.2"
 

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -8,6 +8,7 @@
     "opener:default",
     "dialog:default",
     "fs:default",
+    "os:default",
     "core:path:default",
     "core:event:default",
     "core:webview:allow-set-webview-zoom",
@@ -18,6 +19,9 @@
     "core:window:allow-unmaximize",
     "core:window:allow-close",
     "core:window:allow-is-maximized",
+    "core:window:allow-show",
+    "core:window:allow-set-focus",
+    "core:window:allow-set-decorations",
     "window-state:default"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -538,14 +538,25 @@ pub fn run() {
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
+        .plugin(tauri_plugin_os::init())
         .invoke_handler(tauri::generate_handler![greet, read_exif, scan_folder, scan_files, move_to_trash, export_files, show_main_window])
         .setup(|app| {
-            // Ensure window decorations are disabled at runtime
             #[cfg(desktop)]
             {
                 use tauri::Manager;
                 let window = app.get_webview_window("main").unwrap();
-                window.set_decorations(false).unwrap();
+
+                // On macOS, enable native decorations for traffic light buttons
+                // On Windows/Linux, disable decorations for custom title bar
+                #[cfg(target_os = "macos")]
+                {
+                    window.set_decorations(true).unwrap();
+                }
+
+                #[cfg(not(target_os = "macos"))]
+                {
+                    window.set_decorations(false).unwrap();
+                }
                 // Window will be shown after frontend is ready via show_main_window command
             }
             Ok(())

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -13,9 +13,11 @@
     "windows": [
       {
         "label": "main",
-        "title": "lenslink",
-        "width": 1200,
-        "height": 800,
+        "title": "",
+        "width": 1440,
+        "height": 900,
+        "minWidth": 900,
+        "minHeight": 600,
         "decorations": false,
         "transparent": false,
         "visible": false,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "lenslink",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "identifier": "com.lenslink.app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { open } from '@tauri-apps/plugin-dialog';
 import { convertFileSrc } from '@tauri-apps/api/core';
 import { getCurrentWindow } from '@tauri-apps/api/window';
 import { getTranslations, Language } from './i18n';
+import { usePlatform } from './hooks/usePlatform';
 import logoImg from './assets/logo.png';
 
 const App: React.FC = () => {
@@ -45,6 +46,9 @@ const App: React.FC = () => {
     return (saved === 'zh' || saved === 'en') ? saved : 'zh';
   });
   const t = getTranslations(language);
+
+  // Platform detection for conditional window controls
+  const { isMacOS } = usePlatform();
 
   // Window controls
   const appWindow = getCurrentWindow();
@@ -620,52 +624,63 @@ const App: React.FC = () => {
   
         <div className="flex items-center gap-3" data-tauri-drag-region="false" style={{WebkitAppRegion: 'no-drag'} as any}>
           <div className={`flex rounded-lg border overflow-hidden ${theme === 'dark' ? 'bg-zinc-950 border-zinc-800/50' : 'bg-white border-gray-300/50'}`}>
-            <button 
+            <button
               onClick={handleImportFiles}
               disabled={isLoading}
-              className={`px-4 py-2 text-[11px] font-bold flex items-center gap-2 transition-colors disabled:opacity-50 border-r ${theme === 'dark' ? 'text-zinc-400 hover:bg-zinc-900 border-zinc-800/50' : 'text-gray-600 hover:bg-gray-100 border-gray-300/50'}`}
+              className={`px-3 xl:px-4 py-2 text-[11px] font-bold flex items-center gap-2 transition-colors disabled:opacity-50 border-r ${theme === 'dark' ? 'text-zinc-400 hover:bg-zinc-900 border-zinc-800/50' : 'text-gray-600 hover:bg-gray-100 border-gray-300/50'}`}
+              title={isLoading ? t.buttons.loading : t.buttons.importFiles}
             >
-              <i className={`fa-solid fa-file-circle-plus ${isLoading ? 'animate-pulse' : ''}`}></i> 
-              {isLoading ? t.buttons.loading : t.buttons.importFiles}
+              <i className={`fa-solid fa-file-circle-plus ${isLoading ? 'animate-pulse' : ''}`}></i>
+              <span className="hidden xl:inline">{isLoading ? t.buttons.loading : t.buttons.importFiles}</span>
             </button>
-            <button 
+            <button
               onClick={handleImportFolder}
               disabled={isLoading}
-              className={`px-4 py-2 text-[11px] font-bold flex items-center gap-2 transition-colors disabled:opacity-50 ${theme === 'dark' ? 'text-zinc-400 hover:bg-zinc-900' : 'text-gray-600 hover:bg-gray-100'}`}
+              className={`px-3 xl:px-4 py-2 text-[11px] font-bold flex items-center gap-2 transition-colors disabled:opacity-50 ${theme === 'dark' ? 'text-zinc-400 hover:bg-zinc-900' : 'text-gray-600 hover:bg-gray-100'}`}
+              title={isLoading ? t.buttons.loading : t.buttons.importFolder}
             >
-              <i className={`fa-solid fa-folder-open ${isLoading ? 'animate-pulse' : ''}`}></i> 
-              {isLoading ? t.buttons.loading : t.buttons.importFolder}
+              <i className={`fa-solid fa-folder-open ${isLoading ? 'animate-pulse' : ''}`}></i>
+              <span className="hidden xl:inline">{isLoading ? t.buttons.loading : t.buttons.importFolder}</span>
             </button>
           </div>
-  
-          <button 
+
+          <button
              onClick={() => setShowDeleteConfirm(true)}
              disabled={stats.rejected === 0}
-             className={`px-4 py-2 border rounded-lg text-[11px] font-bold transition-all disabled:opacity-30 disabled:pointer-events-none ${theme === 'dark' ? 'bg-rose-500/10 hover:bg-rose-500 text-rose-500 hover:text-white border-rose-500/30' : 'bg-rose-50 hover:bg-rose-500 text-rose-600 hover:text-white border-rose-300'}`}
+             className={`px-3 xl:px-4 py-2 border rounded-lg text-[11px] font-bold transition-all disabled:opacity-30 disabled:pointer-events-none ${theme === 'dark' ? 'bg-rose-500/10 hover:bg-rose-500 text-rose-500 hover:text-white border-rose-500/30' : 'bg-rose-50 hover:bg-rose-500 text-rose-600 hover:text-white border-rose-300'}`}
+             title={language === 'zh' ? `确认删除 ${stats.rejected} 项` : `Confirm ${stats.rejected} Rejects`}
           >
-            <i className="fa-solid fa-trash-can mr-2"></i> {language === 'zh' ? `确认删除 ${stats.rejected} 项` : `Confirm ${stats.rejected} Rejects`}
+            <i className="fa-solid fa-trash-can xl:mr-2"></i>
+            <span className="hidden xl:inline">{language === 'zh' ? `确认删除 ${stats.rejected} 项` : `Confirm ${stats.rejected} Rejects`}</span>
+            <span className="xl:hidden ml-1">{stats.rejected}</span>
           </button>
 
           {/* Orphan Delete Buttons */}
           <div className={`flex rounded-lg border overflow-hidden ${theme === 'dark' ? 'bg-zinc-950 border-zinc-800/50' : 'bg-white border-gray-300/50'}`}>
-            <button 
+            <button
               onClick={() => handleOrphanDeleteStart('RAW')}
               disabled={stats.orphanRaw === 0}
-              className={`px-3 py-2 text-[10px] font-bold flex items-center gap-1.5 transition-colors disabled:opacity-30 disabled:pointer-events-none border-r ${theme === 'dark' ? 'text-amber-400 hover:bg-amber-500/10 border-zinc-800/50' : 'text-amber-600 hover:bg-amber-50 border-gray-300/50'}`}
+              className={`px-2 xl:px-3 py-2 text-[10px] font-bold flex items-center gap-1.5 transition-colors disabled:opacity-30 disabled:pointer-events-none border-r ${theme === 'dark' ? 'text-amber-400 hover:bg-amber-500/10 border-zinc-800/50' : 'text-amber-600 hover:bg-amber-50 border-gray-300/50'}`}
+              title={language === 'zh' ? `删RAW (${stats.orphanRaw})` : `Del RAW (${stats.orphanRaw})`}
             >
-              <i className="fa-solid fa-file-image"></i> {language === 'zh' ? `删RAW (${stats.orphanRaw})` : `Del RAW (${stats.orphanRaw})`}
+              <i className="fa-solid fa-file-image"></i>
+              <span className="hidden xl:inline">{language === 'zh' ? `删RAW` : `Del RAW`}</span>
+              <span>({stats.orphanRaw})</span>
             </button>
-            <button 
+            <button
               onClick={() => handleOrphanDeleteStart('JPG')}
               disabled={stats.orphanJpg === 0}
-              className={`px-3 py-2 text-[10px] font-bold flex items-center gap-1.5 transition-colors disabled:opacity-30 disabled:pointer-events-none ${theme === 'dark' ? 'text-amber-400 hover:bg-amber-500/10' : 'text-amber-600 hover:bg-amber-50'}`}
+              className={`px-2 xl:px-3 py-2 text-[10px] font-bold flex items-center gap-1.5 transition-colors disabled:opacity-30 disabled:pointer-events-none ${theme === 'dark' ? 'text-amber-400 hover:bg-amber-500/10' : 'text-amber-600 hover:bg-amber-50'}`}
+              title={language === 'zh' ? `删JPG (${stats.orphanJpg})` : `Del JPG (${stats.orphanJpg})`}
             >
-              <i className="fa-solid fa-image"></i> {language === 'zh' ? `删JPG (${stats.orphanJpg})` : `Del JPG (${stats.orphanJpg})`}
+              <i className="fa-solid fa-image"></i>
+              <span className="hidden xl:inline">{language === 'zh' ? `删JPG` : `Del JPG`}</span>
+              <span>({stats.orphanJpg})</span>
             </button>
           </div>
-  
+
           <div className="relative" ref={exportMenuRef}>
-            <button 
+            <button
               onClick={() => {
                 if (stats.picked === 0) {
                   alert("No photos are picked for export.");
@@ -674,9 +689,11 @@ const App: React.FC = () => {
                 setShowExportMenu(!showExportMenu);
               }}
               disabled={stats.picked === 0}
-              className={`px-5 py-2 rounded-lg text-[11px] font-bold shadow-lg flex items-center gap-2 transition-all disabled:opacity-30 disabled:pointer-events-none ${theme === 'dark' ? 'bg-indigo-600 hover:bg-indigo-500 text-white shadow-indigo-600/20' : 'bg-indigo-500 hover:bg-indigo-600 text-white shadow-indigo-500/30'}`}
+              className={`px-3 xl:px-5 py-2 rounded-lg text-[11px] font-bold shadow-lg flex items-center gap-2 transition-all disabled:opacity-30 disabled:pointer-events-none ${theme === 'dark' ? 'bg-indigo-600 hover:bg-indigo-500 text-white shadow-indigo-600/20' : 'bg-indigo-500 hover:bg-indigo-600 text-white shadow-indigo-500/30'}`}
+              title={t.buttons.exportPicks}
             >
-              <i className="fa-solid fa-paper-plane"></i> {t.buttons.exportPicks}
+              <i className="fa-solid fa-paper-plane"></i>
+              <span className="hidden xl:inline">{t.buttons.exportPicks}</span>
             </button>
             {showExportMenu && (
               <div className={`absolute top-full right-0 mt-2 w-44 border rounded-xl shadow-2xl z-50 p-1 flex flex-col ${theme === 'dark' ? 'bg-zinc-900 border-zinc-800' : 'bg-white border-gray-200'}`}>
@@ -695,30 +712,32 @@ const App: React.FC = () => {
             <i className="fa-solid fa-gear text-sm"></i>
           </button>
   
-          {/* Window Controls */}
-          <div className={`flex items-center gap-1 ml-2 border-l pl-3 ${theme === 'dark' ? 'border-zinc-800' : 'border-gray-300'}`}>
-            <button
-              onClick={handleMinimize}
-              className={`w-8 h-8 flex items-center justify-center rounded transition-colors ${theme === 'dark' ? 'hover:bg-zinc-800 text-zinc-400 hover:text-zinc-200' : 'hover:bg-gray-200 text-gray-500 hover:text-gray-700'}`}
-              title={t.window.minimize}
-            >
-              <i className="fa-solid fa-window-minimize text-[10px]"></i>
-            </button>
-            <button
-              onClick={handleMaximize}
-              className={`w-8 h-8 flex items-center justify-center rounded transition-colors ${theme === 'dark' ? 'hover:bg-zinc-800 text-zinc-400 hover:text-zinc-200' : 'hover:bg-gray-200 text-gray-500 hover:text-gray-700'}`}
-              title={t.window.maximize}
-            >
-              <i className="fa-regular fa-window-maximize text-xs"></i>
-            </button>
-            <button
-              onClick={handleClose}
-              className={`w-8 h-8 flex items-center justify-center rounded hover:bg-red-600 transition-colors hover:text-white ${theme === 'dark' ? 'text-zinc-400' : 'text-gray-500'}`}
-              title={t.window.close}
-            >
-              <i className="fa-solid fa-xmark text-sm"></i>
-            </button>
-          </div>
+          {/* Window Controls - Only show on Windows/Linux */}
+          {!isMacOS && (
+            <div className={`flex items-center gap-1 ml-2 border-l pl-3 ${theme === 'dark' ? 'border-zinc-800' : 'border-gray-300'}`}>
+              <button
+                onClick={handleMinimize}
+                className={`w-8 h-8 flex items-center justify-center rounded transition-colors ${theme === 'dark' ? 'hover:bg-zinc-800 text-zinc-400 hover:text-zinc-200' : 'hover:bg-gray-200 text-gray-500 hover:text-gray-700'}`}
+                title={t.window.minimize}
+              >
+                <i className="fa-solid fa-window-minimize text-[10px]"></i>
+              </button>
+              <button
+                onClick={handleMaximize}
+                className={`w-8 h-8 flex items-center justify-center rounded transition-colors ${theme === 'dark' ? 'hover:bg-zinc-800 text-zinc-400 hover:text-zinc-200' : 'hover:bg-gray-200 text-gray-500 hover:text-gray-700'}`}
+                title={t.window.maximize}
+              >
+                <i className="fa-regular fa-window-maximize text-xs"></i>
+              </button>
+              <button
+                onClick={handleClose}
+                className={`w-8 h-8 flex items-center justify-center rounded hover:bg-red-600 transition-colors hover:text-white ${theme === 'dark' ? 'text-zinc-400' : 'text-gray-500'}`}
+                title={t.window.close}
+              >
+                <i className="fa-solid fa-xmark text-sm"></i>
+              </button>
+            </div>
+          )}
         </div>
       </nav>
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { convertFileSrc } from '@tauri-apps/api/core';
 import { getCurrentWindow } from '@tauri-apps/api/window';
 import { getTranslations, Language } from './i18n';
 import { usePlatform } from './hooks/usePlatform';
+import { useTheme } from './hooks/useTheme';
 import logoImg from './assets/logo.png';
 
 const App: React.FC = () => {
@@ -37,10 +38,7 @@ const App: React.FC = () => {
 
   // Settings
   const [showSettings, setShowSettings] = useState(false);
-  const [theme, setTheme] = useState<'light' | 'dark'>(() => {
-    const saved = localStorage.getItem('lenslink-theme');
-    return (saved === 'light' || saved === 'dark') ? saved : 'dark';
-  });
+  const { theme, themeMode, setThemeMode } = useTheme();
   const [language, setLanguage] = useState<Language>(() => {
     const saved = localStorage.getItem('lenslink-language');
     return (saved === 'zh' || saved === 'en') ? saved : 'zh';
@@ -70,11 +68,7 @@ const App: React.FC = () => {
     appWindow.close();
   };
 
-  // Persist theme and language settings
-  useEffect(() => {
-    localStorage.setItem('lenslink-theme', theme);
-  }, [theme]);
-
+  // Persist language setting
   useEffect(() => {
     localStorage.setItem('lenslink-language', language);
   }, [language]);
@@ -875,8 +869,9 @@ const App: React.FC = () => {
         isOpen={showSettings}
         onClose={() => setShowSettings(false)}
         theme={theme}
+        themeMode={themeMode}
         language={language}
-        onThemeChange={setTheme}
+        onThemeModeChange={setThemeMode}
         onLanguageChange={setLanguage}
       />
     </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -621,7 +621,7 @@ const App: React.FC = () => {
             <button
               onClick={handleImportFiles}
               disabled={isLoading}
-              className={`px-3 xl:px-4 py-2 text-[11px] font-bold flex items-center gap-2 transition-colors disabled:opacity-50 border-r ${theme === 'dark' ? 'text-zinc-400 hover:bg-zinc-900 border-zinc-800/50' : 'text-gray-600 hover:bg-gray-100 border-gray-300/50'}`}
+              className={`h-9 px-3 xl:px-4 text-[11px] font-bold flex items-center gap-2 transition-colors disabled:opacity-50 border-r ${theme === 'dark' ? 'text-zinc-400 hover:bg-zinc-900 border-zinc-800/50' : 'text-gray-600 hover:bg-gray-100 border-gray-300/50'}`}
               title={isLoading ? t.buttons.loading : t.buttons.importFiles}
             >
               <i className={`fa-solid fa-file-circle-plus ${isLoading ? 'animate-pulse' : ''}`}></i>
@@ -630,7 +630,7 @@ const App: React.FC = () => {
             <button
               onClick={handleImportFolder}
               disabled={isLoading}
-              className={`px-3 xl:px-4 py-2 text-[11px] font-bold flex items-center gap-2 transition-colors disabled:opacity-50 ${theme === 'dark' ? 'text-zinc-400 hover:bg-zinc-900' : 'text-gray-600 hover:bg-gray-100'}`}
+              className={`h-9 px-3 xl:px-4 text-[11px] font-bold flex items-center gap-2 transition-colors disabled:opacity-50 ${theme === 'dark' ? 'text-zinc-400 hover:bg-zinc-900' : 'text-gray-600 hover:bg-gray-100'}`}
               title={isLoading ? t.buttons.loading : t.buttons.importFolder}
             >
               <i className={`fa-solid fa-folder-open ${isLoading ? 'animate-pulse' : ''}`}></i>
@@ -641,7 +641,7 @@ const App: React.FC = () => {
           <button
              onClick={() => setShowDeleteConfirm(true)}
              disabled={stats.rejected === 0}
-             className={`px-3 xl:px-4 py-2 border rounded-lg text-[11px] font-bold transition-all disabled:opacity-30 disabled:pointer-events-none ${theme === 'dark' ? 'bg-rose-500/10 hover:bg-rose-500 text-rose-500 hover:text-white border-rose-500/30' : 'bg-rose-50 hover:bg-rose-500 text-rose-600 hover:text-white border-rose-300'}`}
+             className={`h-9 px-3 xl:px-4 border rounded-lg text-[11px] font-bold transition-all disabled:opacity-30 disabled:pointer-events-none ${theme === 'dark' ? 'bg-rose-500/10 hover:bg-rose-500 text-rose-500 hover:text-white border-rose-500/30' : 'bg-rose-50 hover:bg-rose-500 text-rose-600 hover:text-white border-rose-300'}`}
              title={language === 'zh' ? `确认删除 ${stats.rejected} 项` : `Confirm ${stats.rejected} Rejects`}
           >
             <i className="fa-solid fa-trash-can xl:mr-2"></i>
@@ -654,7 +654,7 @@ const App: React.FC = () => {
             <button
               onClick={() => handleOrphanDeleteStart('RAW')}
               disabled={stats.orphanRaw === 0}
-              className={`px-2 xl:px-3 py-2 text-[10px] font-bold flex items-center gap-1.5 transition-colors disabled:opacity-30 disabled:pointer-events-none border-r ${theme === 'dark' ? 'text-amber-400 hover:bg-amber-500/10 border-zinc-800/50' : 'text-amber-600 hover:bg-amber-50 border-gray-300/50'}`}
+              className={`h-9 px-2 xl:px-3 text-[11px] font-bold flex items-center gap-1.5 transition-colors disabled:opacity-30 disabled:pointer-events-none border-r ${theme === 'dark' ? 'text-amber-400 hover:bg-amber-500/10 border-zinc-800/50' : 'text-amber-600 hover:bg-amber-50 border-gray-300/50'}`}
               title={language === 'zh' ? `删RAW (${stats.orphanRaw})` : `Del RAW (${stats.orphanRaw})`}
             >
               <i className="fa-solid fa-file-image"></i>
@@ -664,7 +664,7 @@ const App: React.FC = () => {
             <button
               onClick={() => handleOrphanDeleteStart('JPG')}
               disabled={stats.orphanJpg === 0}
-              className={`px-2 xl:px-3 py-2 text-[10px] font-bold flex items-center gap-1.5 transition-colors disabled:opacity-30 disabled:pointer-events-none ${theme === 'dark' ? 'text-amber-400 hover:bg-amber-500/10' : 'text-amber-600 hover:bg-amber-50'}`}
+              className={`h-9 px-2 xl:px-3 text-[11px] font-bold flex items-center gap-1.5 transition-colors disabled:opacity-30 disabled:pointer-events-none ${theme === 'dark' ? 'text-amber-400 hover:bg-amber-500/10' : 'text-amber-600 hover:bg-amber-50'}`}
               title={language === 'zh' ? `删JPG (${stats.orphanJpg})` : `Del JPG (${stats.orphanJpg})`}
             >
               <i className="fa-solid fa-image"></i>
@@ -683,7 +683,7 @@ const App: React.FC = () => {
                 setShowExportMenu(!showExportMenu);
               }}
               disabled={stats.picked === 0}
-              className={`px-3 xl:px-5 py-2 rounded-lg text-[11px] font-bold shadow-lg flex items-center gap-2 transition-all disabled:opacity-30 disabled:pointer-events-none ${theme === 'dark' ? 'bg-indigo-600 hover:bg-indigo-500 text-white shadow-indigo-600/20' : 'bg-indigo-500 hover:bg-indigo-600 text-white shadow-indigo-500/30'}`}
+              className={`h-9 px-3 xl:px-5 rounded-lg text-[11px] font-bold shadow-lg flex items-center gap-2 transition-all disabled:opacity-30 disabled:pointer-events-none ${theme === 'dark' ? 'bg-indigo-600 hover:bg-indigo-500 text-white shadow-indigo-600/20' : 'bg-indigo-500 hover:bg-indigo-600 text-white shadow-indigo-500/30'}`}
               title={t.buttons.exportPicks}
             >
               <i className="fa-solid fa-paper-plane"></i>
@@ -711,21 +711,21 @@ const App: React.FC = () => {
             <div className={`flex items-center gap-1 ml-2 border-l pl-3 ${theme === 'dark' ? 'border-zinc-800' : 'border-gray-300'}`}>
               <button
                 onClick={handleMinimize}
-                className={`w-8 h-8 flex items-center justify-center rounded transition-colors ${theme === 'dark' ? 'hover:bg-zinc-800 text-zinc-400 hover:text-zinc-200' : 'hover:bg-gray-200 text-gray-500 hover:text-gray-700'}`}
+                className={`w-9 h-9 flex items-center justify-center rounded transition-colors ${theme === 'dark' ? 'hover:bg-zinc-800 text-zinc-400 hover:text-zinc-200' : 'hover:bg-gray-200 text-gray-500 hover:text-gray-700'}`}
                 title={t.window.minimize}
               >
                 <i className="fa-solid fa-window-minimize text-[10px]"></i>
               </button>
               <button
                 onClick={handleMaximize}
-                className={`w-8 h-8 flex items-center justify-center rounded transition-colors ${theme === 'dark' ? 'hover:bg-zinc-800 text-zinc-400 hover:text-zinc-200' : 'hover:bg-gray-200 text-gray-500 hover:text-gray-700'}`}
+                className={`w-9 h-9 flex items-center justify-center rounded transition-colors ${theme === 'dark' ? 'hover:bg-zinc-800 text-zinc-400 hover:text-zinc-200' : 'hover:bg-gray-200 text-gray-500 hover:text-gray-700'}`}
                 title={t.window.maximize}
               >
                 <i className="fa-regular fa-window-maximize text-xs"></i>
               </button>
               <button
                 onClick={handleClose}
-                className={`w-8 h-8 flex items-center justify-center rounded hover:bg-red-600 transition-colors hover:text-white ${theme === 'dark' ? 'text-zinc-400' : 'text-gray-500'}`}
+                className={`w-9 h-9 flex items-center justify-center rounded hover:bg-red-600 transition-colors hover:text-white ${theme === 'dark' ? 'text-zinc-400' : 'text-gray-500'}`}
                 title={t.window.close}
               >
                 <i className="fa-solid fa-xmark text-sm"></i>

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import { getTranslations, Language } from '../i18n';
+import { ThemeMode, ResolvedTheme } from '../hooks/useTheme';
 
 interface SettingsPanelProps {
   isOpen: boolean;
   onClose: () => void;
-  theme: 'light' | 'dark';
+  theme: ResolvedTheme;
+  themeMode: ThemeMode;
   language: Language;
-  onThemeChange: (theme: 'light' | 'dark') => void;
+  onThemeModeChange: (mode: ThemeMode) => void;
   onLanguageChange: (language: Language) => void;
 }
 
@@ -14,8 +16,9 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
   isOpen,
   onClose,
   theme,
+  themeMode,
   language,
-  onThemeChange,
+  onThemeModeChange,
   onLanguageChange,
 }) => {
   if (!isOpen) return null;
@@ -25,11 +28,11 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
   return (
     <>
       {/* Backdrop */}
-      <div 
+      <div
         className="fixed inset-0 bg-black/50 backdrop-blur-sm z-40"
         onClick={onClose}
       />
-      
+
       {/* Settings Panel */}
       <div className={`fixed top-16 right-6 w-96 border rounded-xl shadow-2xl z-50 overflow-hidden ${theme === 'dark' ? 'bg-zinc-900 border-zinc-800' : 'bg-white border-gray-200'}`}>
         {/* Header */}
@@ -53,26 +56,43 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
             </label>
             <div className="flex gap-2">
               <button
-                onClick={() => onThemeChange('light')}
-                className={`flex-1 px-4 py-3 rounded-lg text-sm font-bold transition-all ${
-                  theme === 'light'
+                onClick={() => onThemeModeChange('light')}
+                className={`flex-1 px-3 py-3 rounded-lg text-sm font-bold transition-all ${
+                  themeMode === 'light'
                     ? 'bg-indigo-600 text-white shadow-lg shadow-indigo-600/20'
-                    : 'bg-gray-100 text-gray-600 hover:bg-gray-200 hover:text-gray-800'
+                    : theme === 'dark'
+                      ? 'bg-zinc-800 text-zinc-400 hover:bg-zinc-700 hover:text-zinc-200'
+                      : 'bg-gray-100 text-gray-600 hover:bg-gray-200 hover:text-gray-800'
                 }`}
               >
-                <i className="fa-solid fa-sun mr-2"></i>
+                <i className="fa-solid fa-sun mr-1.5"></i>
                 {t.settings.lightMode}
               </button>
               <button
-                onClick={() => onThemeChange('dark')}
-                className={`flex-1 px-4 py-3 rounded-lg text-sm font-bold transition-all ${
-                  theme === 'dark'
+                onClick={() => onThemeModeChange('dark')}
+                className={`flex-1 px-3 py-3 rounded-lg text-sm font-bold transition-all ${
+                  themeMode === 'dark'
                     ? 'bg-indigo-600 text-white shadow-lg shadow-indigo-600/20'
-                    : 'bg-gray-100 text-gray-600 hover:bg-gray-200 hover:text-gray-800'
+                    : theme === 'dark'
+                      ? 'bg-zinc-800 text-zinc-400 hover:bg-zinc-700 hover:text-zinc-200'
+                      : 'bg-gray-100 text-gray-600 hover:bg-gray-200 hover:text-gray-800'
                 }`}
               >
-                <i className="fa-solid fa-moon mr-2"></i>
+                <i className="fa-solid fa-moon mr-1.5"></i>
                 {t.settings.darkMode}
+              </button>
+              <button
+                onClick={() => onThemeModeChange('system')}
+                className={`flex-1 px-3 py-3 rounded-lg text-sm font-bold transition-all ${
+                  themeMode === 'system'
+                    ? 'bg-indigo-600 text-white shadow-lg shadow-indigo-600/20'
+                    : theme === 'dark'
+                      ? 'bg-zinc-800 text-zinc-400 hover:bg-zinc-700 hover:text-zinc-200'
+                      : 'bg-gray-100 text-gray-600 hover:bg-gray-200 hover:text-gray-800'
+                }`}
+              >
+                <i className="fa-solid fa-circle-half-stroke mr-1.5"></i>
+                {t.settings.systemMode}
               </button>
             </div>
           </div>
@@ -89,7 +109,9 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
                 className={`flex-1 px-4 py-3 rounded-lg text-sm font-bold transition-all ${
                   language === 'zh'
                     ? 'bg-indigo-600 text-white shadow-lg shadow-indigo-600/20'
-                    : 'bg-gray-100 text-gray-600 hover:bg-gray-200 hover:text-gray-800'
+                    : theme === 'dark'
+                      ? 'bg-zinc-800 text-zinc-400 hover:bg-zinc-700 hover:text-zinc-200'
+                      : 'bg-gray-100 text-gray-600 hover:bg-gray-200 hover:text-gray-800'
                 }`}
               >
                 {t.settings.chinese}
@@ -99,7 +121,9 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
                 className={`flex-1 px-4 py-3 rounded-lg text-sm font-bold transition-all ${
                   language === 'en'
                     ? 'bg-indigo-600 text-white shadow-lg shadow-indigo-600/20'
-                    : 'bg-gray-100 text-gray-600 hover:bg-gray-200 hover:text-gray-800'
+                    : theme === 'dark'
+                      ? 'bg-zinc-800 text-zinc-400 hover:bg-zinc-700 hover:text-zinc-200'
+                      : 'bg-gray-100 text-gray-600 hover:bg-gray-200 hover:text-gray-800'
                 }`}
               >
                 {t.settings.english}

--- a/src/hooks/usePlatform.ts
+++ b/src/hooks/usePlatform.ts
@@ -1,0 +1,19 @@
+import { useState, useEffect } from 'react';
+import { platform } from '@tauri-apps/plugin-os';
+
+export function usePlatform() {
+  const [currentPlatform, setCurrentPlatform] = useState<string>('');
+  const [isMacOS, setIsMacOS] = useState(false);
+  const [isWindows, setIsWindows] = useState(false);
+  const [isLinux, setIsLinux] = useState(false);
+
+  useEffect(() => {
+    const p = platform();
+    setCurrentPlatform(p);
+    setIsMacOS(p === 'macos');
+    setIsWindows(p === 'windows');
+    setIsLinux(p === 'linux');
+  }, []);
+
+  return { platform: currentPlatform, isMacOS, isWindows, isLinux };
+}

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,0 +1,66 @@
+import { useState, useEffect } from 'react';
+
+export type ThemeMode = 'light' | 'dark' | 'system';
+export type ResolvedTheme = 'light' | 'dark';
+
+const STORAGE_KEY = 'lenslink-theme';
+
+function getSystemTheme(): ResolvedTheme {
+  if (typeof window !== 'undefined' && window.matchMedia) {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  }
+  return 'dark';
+}
+
+export function useTheme() {
+  const [themeMode, setThemeMode] = useState<ThemeMode>(() => {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (saved === 'light' || saved === 'dark' || saved === 'system') {
+      return saved;
+    }
+    return 'dark';
+  });
+
+  const [resolvedTheme, setResolvedTheme] = useState<ResolvedTheme>(() => {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (saved === 'light' || saved === 'dark') {
+      return saved;
+    }
+    if (saved === 'system') {
+      return getSystemTheme();
+    }
+    return 'dark';
+  });
+
+  // Listen for system theme changes
+  useEffect(() => {
+    if (themeMode !== 'system') {
+      setResolvedTheme(themeMode);
+      return;
+    }
+
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+
+    const handleChange = (e: MediaQueryListEvent) => {
+      setResolvedTheme(e.matches ? 'dark' : 'light');
+    };
+
+    // Set initial value
+    setResolvedTheme(mediaQuery.matches ? 'dark' : 'light');
+
+    // Listen for changes
+    mediaQuery.addEventListener('change', handleChange);
+    return () => mediaQuery.removeEventListener('change', handleChange);
+  }, [themeMode]);
+
+  // Persist theme mode to localStorage
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, themeMode);
+  }, [themeMode]);
+
+  return {
+    themeMode,
+    theme: resolvedTheme,
+    setThemeMode,
+  };
+}

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -86,8 +86,9 @@ export const translations = {
     settings: {
       title: '设置',
       theme: '主题',
-      lightMode: '浅色模式',
-      darkMode: '深色模式',
+      lightMode: '浅色',
+      darkMode: '深色',
+      systemMode: '系统',
       language: '语言',
       chinese: '中文',
       english: 'English',
@@ -309,8 +310,9 @@ export const translations = {
     settings: {
       title: 'Settings',
       theme: 'Theme',
-      lightMode: 'Light Mode',
-      darkMode: 'Dark Mode',
+      lightMode: 'Light',
+      darkMode: 'Dark',
+      systemMode: 'System',
       language: 'Language',
       chinese: '中文',
       english: 'English',


### PR DESCRIPTION
## 概述

  优化窗口控制和主题设置，提升跨平台体验和代码可维护性。
  已在 MacOS 端及 Windows 端进行测试。

  ## 主要改动

  ### 1. macOS 原生窗口控制
  - macOS 启用原生窗口装饰，支持系统全屏功能
  - Windows/Linux 保留自定义窗口控制按钮
  - 添加 `usePlatform` hook 支持跨平台判断

  ### 2. 导航栏响应式优化
  - 小窗口（< 1280px）仅显示图标
  - 大窗口（≥ 1280px）显示图标 + 文字
  - 统一导航栏的按钮高度

  ### 3. 跟随系统主题
  - 主题设置新增"跟随系统"选项
  - 自动跟随操作系统深色/浅色模式切换
  - 抽离主题逻辑到 `useTheme` hook

  ## 新增文件

  - `src/hooks/usePlatform.ts` - 平台检测 hook
  - `src/hooks/useTheme.ts` - 主题管理 hook

  ## 依赖变更

  - 新增 `@tauri-apps/plugin-os` 用于平台检测
  - 新增 `tauri-plugin-os` (Rust)

实现 #2 

<img width="2940" height="1716" alt="image" src="https://github.com/user-attachments/assets/f4eb0288-4729-4d9f-8c3e-f9ba1a639542" />

<img width="2940" height="1716" alt="image" src="https://github.com/user-attachments/assets/8f8530e6-6f9e-4752-b696-3b7503d48d22" />
